### PR TITLE
Add optimistic update logic to canvas

### DIFF
--- a/frontend2/src/contexts/canvas.ts
+++ b/frontend2/src/contexts/canvas.ts
@@ -1,8 +1,10 @@
+import { useEffect } from "react";
 import { create } from "zustand";
 
 import { STROKE_COLORS, STROKE_WIDTH_CONFIG } from "@/constants/canvas";
 import { RgbaColor } from "@/utils/color";
 import { createEventEmitter } from "@/utils/eventEmitter";
+import { isServer } from "@/utils/isServer";
 
 export type CanvasCommand = "clearChangedPixels";
 
@@ -22,14 +24,24 @@ export interface PixelData {
   b: number;
 }
 
+/** Format: { "x-y": PixelData } */
+export type ImagePatch = Record<`${number}-${number}`, PixelData>;
+
+export interface OptimisticUpdate {
+  /** Collection of pixels that changed */
+  imagePatch: ImagePatch;
+  /** Timestamp in milliseconds when the patch was submitted to the server */
+  committedAt: number;
+}
+
 export interface CanvasState {
   isInitialized: boolean;
   isViewOnly: boolean;
   setViewOnly: (isViewOnly: boolean) => void;
   strokeColor: RgbaColor;
   strokeWidth: number;
-  /** Format: { "x-y": PixelData } */
-  pixelsChanged: Record<`${number}-${number}`, PixelData>;
+  optimisticUpdates: Array<OptimisticUpdate>;
+  pixelsChanged: ImagePatch;
 }
 
 export const useCanvasState = create<CanvasState>((set, get) => ({
@@ -47,5 +59,34 @@ export const useCanvasState = create<CanvasState>((set, get) => ({
   },
   strokeColor: STROKE_COLORS[0],
   strokeWidth: STROKE_WIDTH_CONFIG.min,
+  optimisticUpdates: [],
   pixelsChanged: {},
 }));
+
+/**
+ * Since transactions should be reflected in the aggregated canvas after only a few seconds,
+ * we can delete old optimistic updates to reduce our memory usage and reduce the time it takes
+ * to recompute the current canvas after we fetch the base canvas image.
+ */
+export function useOptimisticUpdateGarbageCollector() {
+  /** Time in milliseconds after which optimistic updates should be garbage collected */
+  const EXPIRATION_TIME = 10_000;
+
+  useEffect(() => {
+    if (isServer()) return;
+
+    const interval = window.setInterval(() => {
+      const { optimisticUpdates } = useCanvasState.getState();
+      if (!optimisticUpdates.length) return;
+
+      const newOptimisticUpdates = optimisticUpdates.filter(
+        (ou) => ou.committedAt + EXPIRATION_TIME > Date.now(),
+      );
+      useCanvasState.setState({ optimisticUpdates: newOptimisticUpdates });
+    }, EXPIRATION_TIME);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, []);
+}

--- a/frontend2/src/contexts/wallet.tsx
+++ b/frontend2/src/contexts/wallet.tsx
@@ -24,9 +24,9 @@ export type SupportedNetworkName = NetworkName.Mainnet | NetworkName.Testnet;
 
 export const useAptosNetworkState = create<AptosNetworkState>((set) => ({
   network: isServer()
-    ? NetworkName.Mainnet
+    ? NetworkName.Testnet
     : ((window.localStorage.getItem("aptos-network") ??
-        NetworkName.Mainnet) as SupportedNetworkName),
+        NetworkName.Testnet) as SupportedNetworkName),
   setNetwork: (network) => {
     set({ network });
     window.localStorage.setItem("aptos-network", network);


### PR DESCRIPTION
This PR sets up a way for optimistic updates to be applied to the canvas so that submitted transactions can be reflected immediately after completion.

Additionally, there is a garbage collector that deletes old optimistic updates after it's safe to assume that they're reflected in the aggregated canvas image.