### PR TITLE
Fix for wrong flag on mobile supported wallets

### DIFF
--- a/frontend2/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/frontend2/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -50,7 +50,7 @@ function WalletConnectButton({ wallet, connect }: WalletConnectButtonProps) {
   const mobileSupport = wallet.deeplinkProvider;
 
   if (!isWalletReady && isRedirectable()) {
-    if (!mobileSupport) {
+    if (mobileSupport) {
       return (
         <div
           className={flex({


### PR DESCRIPTION
This flag was backwards

<img width="433" alt="Screenshot 2023-10-11 at 11 54 00 PM" src="https://github.com/aptos-labs/graffio/assets/19931667/6ffceebc-5860-4aa3-b7b6-c5084ccd94a1">
