### PR TITLE
Prevent drawing before connecting wallet

### DIFF
--- a/frontend2/src/app/(home)/MobileCanvasFooter.tsx
+++ b/frontend2/src/app/(home)/MobileCanvasFooter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { css } from "styled-system/css";
 import { flex, stack } from "styled-system/patterns";
@@ -11,6 +12,7 @@ import { EyeIcon } from "@/components/Icons/EyeIcon";
 import { useCanvasState } from "@/contexts/canvas";
 
 export function MobileCanvasFooter() {
+  const { connected } = useWallet();
   const isViewOnly = useCanvasState((s) => s.isViewOnly);
   const setViewOnly = useCanvasState((s) => s.setViewOnly);
 
@@ -41,6 +43,7 @@ export function MobileCanvasFooter() {
               onClick={() => {
                 setViewOnly(false);
               }}
+              disabled={!connected}
               className={css({ w: "100%" })}
             >
               Go to Draw Mode

--- a/frontend2/src/app/(home)/page.tsx
+++ b/frontend2/src/app/(home)/page.tsx
@@ -16,9 +16,11 @@ export default function HomePage() {
       <main className={main}>
         <DesktopCanvasHeader />
         <MobileCanvasHeader />
-        <div className={canvasWrapper}>
+        <div className={css({ position: "relative", h: "100%", w: "100%" })}>
           <MobileCanvasSidePanel />
-          <CanvasContainer />
+          <div className={css({ position: "absolute", inset: 0, h: "100%", w: "100%" })}>
+            <CanvasContainer />
+          </div>
         </div>
         <MobileCanvasFooter />
       </main>
@@ -52,11 +54,4 @@ const main = css({
     p: 32,
     gap: 24,
   },
-});
-
-const canvasWrapper = css({
-  h: "100%",
-  w: "100%",
-  overflow: "hidden",
-  position: "relative",
 });

--- a/frontend2/src/components/Canvas/index.tsx
+++ b/frontend2/src/components/Canvas/index.tsx
@@ -16,9 +16,6 @@ import { alterImagePixels, createSquareImage } from "./drawImage";
 import { mousePan, pinchZoom, wheelPan, wheelZoom } from "./gestures";
 import { EventCanvas, Point } from "./types";
 
-// TODO: Consider reversing wheel events for mouse users
-// TODO: Add grid lines when zoom reaches ~50x
-
 export interface CanvasProps {
   height: number;
   width: number;

--- a/frontend2/src/components/ConnectWalletModal/DisconnectWalletModal.tsx
+++ b/frontend2/src/components/ConnectWalletModal/DisconnectWalletModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { emitCanvasCommand, useCanvasState } from "@/contexts/canvas";
+import { useCanvasState } from "@/contexts/canvas";
 
 import { DeleteModalContent, openModal } from "../Modal";
 
@@ -23,9 +23,9 @@ function DisconnectWalletModal(props: DisconnectWalletModalProps) {
       content="Are you sure you want to disconnect your wallet?"
       deleteLabel="Disconnect"
       onConfirm={() => {
+        const hasToggled = useCanvasState.getState().setViewOnly(true);
+        if (!hasToggled) return;
         props.disconnect();
-        useCanvasState.setState({ isViewOnly: true });
-        emitCanvasCommand("clearChangedPixels");
         props.hide();
       }}
       hide={props.hide}

--- a/frontend2/src/components/ConnectWalletModal/DisconnectWalletModal.tsx
+++ b/frontend2/src/components/ConnectWalletModal/DisconnectWalletModal.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { emitCanvasCommand, useCanvasState } from "@/contexts/canvas";
+
 import { DeleteModalContent, openModal } from "../Modal";
 
 export function openDisconnectWalletModal(props: Omit<DisconnectWalletModalProps, "hide">) {
@@ -20,6 +24,8 @@ function DisconnectWalletModal(props: DisconnectWalletModalProps) {
       deleteLabel="Disconnect"
       onConfirm={() => {
         props.disconnect();
+        useCanvasState.setState({ isViewOnly: true });
+        emitCanvasCommand("clearChangedPixels");
         props.hide();
       }}
       hide={props.hide}

--- a/frontend2/src/components/DrawingControls/DrawModeToggle.tsx
+++ b/frontend2/src/components/DrawingControls/DrawModeToggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { css } from "styled-system/css";
 import { stack } from "styled-system/patterns";
 
@@ -10,6 +11,7 @@ import { EditBoxIcon } from "../Icons/EditBoxIcon";
 import { EyeIcon } from "../Icons/EyeIcon";
 
 export function DrawModeToggle() {
+  const { connected } = useWallet();
   const isViewOnly = useCanvasState((s) => s.isViewOnly);
   const setViewOnly = useCanvasState((s) => s.setViewOnly);
 
@@ -18,6 +20,7 @@ export function DrawModeToggle() {
       <Button
         iconOnly
         aria-label={isViewOnly ? "Go to Draw Mode" : "Back to View Only"}
+        disabled={isViewOnly && !connected}
         onClick={() => {
           setViewOnly(!isViewOnly);
         }}

--- a/frontend2/src/contexts/canvas.ts
+++ b/frontend2/src/contexts/canvas.ts
@@ -37,7 +37,7 @@ export interface OptimisticUpdate {
 export interface CanvasState {
   isInitialized: boolean;
   isViewOnly: boolean;
-  setViewOnly: (isViewOnly: boolean) => void;
+  setViewOnly: (isViewOnly: boolean) => boolean;
   strokeColor: RgbaColor;
   strokeWidth: number;
   optimisticUpdates: Array<OptimisticUpdate>;
@@ -52,10 +52,11 @@ export const useCanvasState = create<CanvasState>((set, get) => ({
       const hasConfirmed = window.confirm(
         "You have unsaved changes on the board. Are you sure you want to discard them?",
       );
-      if (hasConfirmed) emitCanvasCommand("clearChangedPixels");
-      else return;
+      if (!hasConfirmed) return false;
+      emitCanvasCommand("clearChangedPixels");
     }
     set({ isViewOnly });
+    return true;
   },
   strokeColor: STROKE_COLORS[0],
   strokeWidth: STROKE_WIDTH_CONFIG.min,


### PR DESCRIPTION
The draw mode button will be disabled until a wallet is connected.
When disconnecting a wallet, any in progress drawings will be discarded.


https://github.com/aptos-labs/graffio/assets/25761639/43afcf28-9b3b-4820-9dda-57480b06a157

