### PR TITLE
Enforce per-transaction pixel limit

### DIFF
--- a/frontend2/src/components/Canvas/drawImage.ts
+++ b/frontend2/src/components/Canvas/drawImage.ts
@@ -92,16 +92,16 @@ export function alterImagePixels({
   // Filter out out-of-bounds points
   points = points.filter(({ x, y }) => x >= 0 && x < size && y >= 0 && y < size);
 
-  const nextPixelsChanged = { ...pixelsChanged };
+  const nextPixelsChanged = new Map(pixelsChanged);
   for (const point of points) {
-    if (Object.keys(nextPixelsChanged).length >= MAX_PIXELS_PER_TXN) break;
-    nextPixelsChanged[`${point.x}-${point.y}`] = {
+    if (nextPixelsChanged.size >= MAX_PIXELS_PER_TXN) break;
+    nextPixelsChanged.set(`${point.x}-${point.y}`, {
       x: point.x,
       y: point.y,
       r: strokeColor.red,
       g: strokeColor.green,
       b: strokeColor.blue,
-    };
+    });
     const index = (point.y * size + point.x) * 4;
     pixelArray[index + 0] = strokeColor.red; // R value
     pixelArray[index + 1] = strokeColor.green; // G value

--- a/frontend2/src/components/Canvas/drawImage.ts
+++ b/frontend2/src/components/Canvas/drawImage.ts
@@ -1,5 +1,6 @@
 import { fabric } from "fabric";
 
+import { MAX_PIXELS_PER_TXN } from "@/constants/canvas";
 import { useCanvasState } from "@/contexts/canvas";
 import { createTempCanvas } from "@/utils/tempCanvas";
 
@@ -93,6 +94,7 @@ export function alterImagePixels({
 
   const nextPixelsChanged = { ...pixelsChanged };
   for (const point of points) {
+    if (Object.keys(nextPixelsChanged).length >= MAX_PIXELS_PER_TXN) break;
     nextPixelsChanged[`${point.x}-${point.y}`] = {
       x: point.x,
       y: point.y,

--- a/frontend2/src/components/Canvas/index.tsx
+++ b/frontend2/src/components/Canvas/index.tsx
@@ -96,7 +96,7 @@ export function Canvas({ height, width, baseImage }: CanvasProps) {
       const allImagePatches = optimisticUpdates.map((ou) => ou.imagePatch).concat(pixelsChanged);
 
       for (const imagePatch of allImagePatches) {
-        for (const pixelChanged of Object.values(imagePatch)) {
+        for (const pixelChanged of imagePatch.values()) {
           const index = (pixelChanged.y * PIXELS_PER_SIDE + pixelChanged.x) * 4;
           newPixelArray[index + 0] = pixelChanged.r; // R value
           newPixelArray[index + 1] = pixelChanged.g; // G value
@@ -236,7 +236,7 @@ export function Canvas({ height, width, baseImage }: CanvasProps) {
     const { optimisticUpdates } = useCanvasState.getState();
     const imagePatches = optimisticUpdates.map((ou) => ou.imagePatch);
     for (const imagePatch of imagePatches) {
-      for (const pixelChanged of Object.values(imagePatch)) {
+      for (const pixelChanged of imagePatch.values()) {
         const index = (pixelChanged.y * PIXELS_PER_SIDE + pixelChanged.x) * 4;
         newPixelArray[index + 0] = pixelChanged.r; // R value
         newPixelArray[index + 1] = pixelChanged.g; // G value
@@ -253,7 +253,7 @@ export function Canvas({ height, width, baseImage }: CanvasProps) {
       cleanUp();
     });
 
-    useCanvasState.setState({ pixelsChanged: {} });
+    useCanvasState.setState({ pixelsChanged: new Map() });
     pixelArrayRef.current = new Uint8ClampedArray(newPixelArray);
   });
 

--- a/frontend2/src/components/CanvasActions/index.tsx
+++ b/frontend2/src/components/CanvasActions/index.tsx
@@ -18,7 +18,7 @@ export function CanvasActions() {
   const { signAndSubmitTransaction } = useWallet();
   const setViewOnly = useCanvasState((s) => s.setViewOnly);
   const pixelsChanged = useCanvasState((s) => s.pixelsChanged);
-  const changedPixelsCount = Object.keys(pixelsChanged).length;
+  const changedPixelsCount = pixelsChanged.size;
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const cancel = () => {
@@ -37,7 +37,7 @@ export function CanvasActions() {
     const rs = [];
     const gs = [];
     const bs = [];
-    for (const pixelChanged of Object.values(pixelsChanged)) {
+    for (const pixelChanged of pixelsChanged.values()) {
       xs.push(pixelChanged.x);
       ys.push(pixelChanged.y);
       rs.push(pixelChanged.r);
@@ -60,7 +60,10 @@ export function CanvasActions() {
         imagePatch: pixelsChanged,
         committedAt: Date.now(),
       });
-      useCanvasState.setState({ pixelsChanged: {}, optimisticUpdates: newOptimisticUpdates });
+      useCanvasState.setState({
+        pixelsChanged: new Map(),
+        optimisticUpdates: newOptimisticUpdates,
+      });
       toast({ id: "add-success", variant: "success", content: "Added!" });
     } catch {
       toast({

--- a/frontend2/src/components/DrawingControls/PaintInfo.tsx
+++ b/frontend2/src/components/DrawingControls/PaintInfo.tsx
@@ -16,7 +16,7 @@ export interface PaintInfoProps {
 
 export function PaintInfo({ direction }: PaintInfoProps) {
   const pixelsChanged = useCanvasState((s) => s.pixelsChanged);
-  const changedPixelsCount = Object.keys(pixelsChanged).length;
+  const changedPixelsCount = pixelsChanged.size;
   const limitReached = changedPixelsCount >= MAX_PIXELS_PER_TXN;
 
   useEffect(() => {

--- a/frontend2/src/components/DrawingControls/PaintInfo.tsx
+++ b/frontend2/src/components/DrawingControls/PaintInfo.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useEffect } from "react";
 import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 
+import { MAX_PIXELS_PER_TXN } from "@/constants/canvas";
 import { useCanvasState } from "@/contexts/canvas";
 
 import { PaintIcon } from "../Icons/PaintIcon";
+import { removeToast, toast } from "../Toast";
 
 export interface PaintInfoProps {
   direction: "row" | "column";
@@ -14,9 +17,31 @@ export interface PaintInfoProps {
 export function PaintInfo({ direction }: PaintInfoProps) {
   const pixelsChanged = useCanvasState((s) => s.pixelsChanged);
   const changedPixelsCount = Object.keys(pixelsChanged).length;
+  const limitReached = changedPixelsCount >= MAX_PIXELS_PER_TXN;
+
+  useEffect(() => {
+    const TOAST_ID = "pixel-limit-reached";
+    if (limitReached) {
+      toast({
+        id: TOAST_ID,
+        variant: "warning",
+        content: "Pixel limit per transaction reached",
+        duration: null,
+      });
+    } else {
+      removeToast(TOAST_ID);
+    }
+  }, [limitReached]);
 
   return (
-    <div className={flex({ direction, align: "center", gap: { base: 8, md: 16 }, color: "text" })}>
+    <div
+      className={flex({
+        direction,
+        align: "center",
+        gap: { base: 8, md: 16 },
+        color: limitReached ? "error" : "text",
+      })}
+    >
       <PaintIcon />
       <div className={css({ textStyle: "body.sm.regular", textAlign: "center" })}>
         {changedPixelsCount.toLocaleString()} <br /> Pixels

--- a/frontend2/src/constants/canvas.ts
+++ b/frontend2/src/constants/canvas.ts
@@ -2,6 +2,8 @@ import { rgba } from "@/utils/color";
 
 export const PIXELS_PER_SIDE = 1000;
 
+export const MAX_PIXELS_PER_TXN = 800;
+
 export const STROKE_COLORS = [
   rgba({ name: "black", r: 0, g: 0, b: 0 }),
   rgba({ name: "white", r: 255, g: 255, b: 255 }),

--- a/frontend2/src/contexts/canvas.ts
+++ b/frontend2/src/contexts/canvas.ts
@@ -25,7 +25,7 @@ export interface PixelData {
 }
 
 /** Format: { "x-y": PixelData } */
-export type ImagePatch = Record<`${number}-${number}`, PixelData>;
+export type ImagePatch = Map<`${number}-${number}`, PixelData>;
 
 export interface OptimisticUpdate {
   /** Collection of pixels that changed */
@@ -48,7 +48,7 @@ export const useCanvasState = create<CanvasState>((set, get) => ({
   isInitialized: false,
   isViewOnly: true,
   setViewOnly: (isViewOnly) => {
-    if (isViewOnly && Object.keys(get().pixelsChanged).length) {
+    if (isViewOnly && get().pixelsChanged.size) {
       const hasConfirmed = window.confirm(
         "You have unsaved changes on the board. Are you sure you want to discard them?",
       );
@@ -61,7 +61,7 @@ export const useCanvasState = create<CanvasState>((set, get) => ({
   strokeColor: STROKE_COLORS[0],
   strokeWidth: STROKE_WIDTH_CONFIG.min,
   optimisticUpdates: [],
-  pixelsChanged: {},
+  pixelsChanged: new Map(),
 }));
 
 /**


### PR DESCRIPTION
The  800 pixel per-transaction limit will now be enforced.
Also, the ImagePatch type has been updated from an object to a Map for more performant operations (notably more performant size checking)


https://github.com/aptos-labs/graffio/assets/25761639/4726a0c0-490f-42b4-ba45-3d723f25d212