### PR TITLE
Bumped `@identity-connect/wallet-adapter-plugin` to 1.0.6

### DIFF
--- a/frontend2/package.json
+++ b/frontend2/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@aptos-labs/wallet-adapter-react": "^1.3.2",
     "@ducanh2912/next-pwa": "^9.7.1",
-    "@identity-connect/wallet-adapter-plugin": "^1.0.4",
+    "@identity-connect/wallet-adapter-plugin": "^1.0.6",
     "@martianwallet/aptos-wallet-adapter": "^0.0.4",
     "@pontem/wallet-adapter-plugin": "^0.2.0",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/frontend2/pnpm-lock.yaml
+++ b/frontend2/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 patchedDependencies:
   '@types/fabric@5.3.4':
     hash: 4qcck34a57pzwwc6crpaydnwkq
@@ -20,8 +16,8 @@ dependencies:
     specifier: ^9.7.1
     version: 9.7.1(next@13.5.4)(webpack@5.88.2)
   '@identity-connect/wallet-adapter-plugin':
-    specifier: ^1.0.4
-    version: 1.0.4
+    specifier: ^1.0.6
+    version: 1.0.6
   '@martianwallet/aptos-wallet-adapter':
     specifier: ^0.0.4
     version: 0.0.4
@@ -2074,8 +2070,8 @@ packages:
       - debug
     dev: false
 
-  /@identity-connect/dapp-sdk@0.3.1:
-    resolution: {integrity: sha512-o5CWgaw7vw2VVAUesPSACO/Ho0FjbuuSQzjduDRHny86DZH59oPaboSztgKl1bmGkDBsyxS2lYFrYZwnaQhtbg==}
+  /@identity-connect/dapp-sdk@0.3.3:
+    resolution: {integrity: sha512-qvVdDVEW1+eLGVvzHAzjr6yDocK+OkxOgLTo1si0yZFF+J2nlqzdkWPAInSR1378MKapE76zCqmLXUu15Ygukw==}
     dependencies:
       '@identity-connect/api': 0.3.0
       '@identity-connect/crypto': 0.1.3
@@ -2085,12 +2081,12 @@ packages:
       - debug
     dev: false
 
-  /@identity-connect/wallet-adapter-plugin@1.0.4:
-    resolution: {integrity: sha512-vYCl76FINBxBCjPvqd9ENSZbkBfqwQxPEBuuK+GWdDT+p8+da2M27WPJFVLdfBYe5UhUSZ1hADa1KWejgRCHhA==}
+  /@identity-connect/wallet-adapter-plugin@1.0.6:
+    resolution: {integrity: sha512-9CCV3EmKDa+yxDlu9IENdG08CPTAFGEERic0sUREcTafgA8xxCmIT4xzFbeIeRswCIHnh3hPcbYxO1hjaWsXoQ==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.5.1
       '@identity-connect/api': 0.3.0
-      '@identity-connect/dapp-sdk': 0.3.1
+      '@identity-connect/dapp-sdk': 0.3.3
       aptos: 1.20.0
     transitivePeerDependencies:
       - debug
@@ -10450,3 +10446,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
To fix sequence number mismatch

Tested that sequence number is automatically re-freshed during development