### PR TITLE
Implement undo functionality

### DIFF
--- a/frontend2/src/app/(home)/MobileCanvasHeader.tsx
+++ b/frontend2/src/app/(home)/MobileCanvasHeader.tsx
@@ -9,6 +9,7 @@ export function MobileCanvasHeader() {
       className={css({
         display: "flex",
         md: { display: "none" },
+        gap: 8,
         justifyContent: "space-between",
         alignItems: "center",
       })}

--- a/frontend2/src/components/Button/index.tsx
+++ b/frontend2/src/components/Button/index.tsx
@@ -15,13 +15,16 @@ export interface ButtonProps extends ButtonAttributes, ButtonVariants {
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant = "primary", size, iconOnly, loading, disabled, className, ...props }, ref) => {
+  (
+    { variant = "primary", size, iconOnly, rounded, loading, disabled, className, ...props },
+    ref,
+  ) => {
     return (
       <button
         ref={ref}
         data-loading={loading || undefined}
         disabled={disabled || loading}
-        className={cx(buttonStyles({ variant, size, iconOnly }), className)}
+        className={cx(buttonStyles({ variant, size, iconOnly, rounded }), className)}
         {...props}
       >
         <div className={center({ visibility: loading ? "hidden" : "visible", gap: 8 })}>
@@ -122,7 +125,8 @@ const buttonStyles = cva({
       sm: { textStyle: "body.sm.medium", px: 20, h: 40, rounded: "md" },
       md: { textStyle: "body.md.medium", px: 20, h: 48, rounded: "md" },
     },
-    iconOnly: { true: { px: 0, rounded: "full" } },
+    iconOnly: { true: { px: 0 } },
+    rounded: { true: { rounded: "full" } },
   },
 
   compoundVariants: [

--- a/frontend2/src/components/Canvas/drawImage.ts
+++ b/frontend2/src/components/Canvas/drawImage.ts
@@ -1,7 +1,8 @@
 import { fabric } from "fabric";
+import { MutableRefObject } from "react";
 
 import { MAX_PIXELS_PER_TXN, MAX_PIXELS_PER_TXN_ADMIN } from "@/constants/canvas";
-import { useCanvasState } from "@/contexts/canvas";
+import { ImagePatch, useCanvasState } from "@/contexts/canvas";
 import { createTempCanvas } from "@/utils/tempCanvas";
 
 import { EventCanvas, Point } from "./types";
@@ -45,6 +46,47 @@ export function createSquareImage({ size, pixelArray, canvas, imageRef }: Create
   );
 }
 
+export interface ApplyImagePatchesArgs {
+  canvas: fabric.Canvas;
+  image: fabric.Image;
+  size: number;
+  basePixelArray: Uint8ClampedArray;
+  imagePatches: Array<ImagePatch>;
+  pixelArrayRef: MutableRefObject<Uint8ClampedArray>;
+}
+
+export function applyImagePatches({
+  canvas,
+  image,
+  size,
+  pixelArrayRef,
+  basePixelArray,
+  imagePatches,
+}: ApplyImagePatchesArgs) {
+  // Create new pixel array with the image patches applied
+  const newPixelArray = new Uint8ClampedArray(basePixelArray);
+  for (const imagePatch of imagePatches) {
+    for (const pixelChanged of imagePatch.values()) {
+      const index = (pixelChanged.y * size + pixelChanged.x) * 4;
+      newPixelArray[index + 0] = pixelChanged.r; // R value
+      newPixelArray[index + 1] = pixelChanged.g; // G value
+      newPixelArray[index + 2] = pixelChanged.b; // B value
+      newPixelArray[index + 3] = 255; // A value
+    }
+  }
+
+  // Save new pixel array to the ref
+  pixelArrayRef.current = newPixelArray;
+
+  const [tempCanvas, cleanUp] = createTempCanvas(newPixelArray, size);
+
+  // Update fabric image with data from temporary canvas and clean up when done
+  image.setSrc(tempCanvas.toDataURL(), () => {
+    canvas.renderAll();
+    cleanUp();
+  });
+}
+
 export interface AlterImagePixelsArgs {
   image: fabric.Image;
   size: number;
@@ -52,6 +94,7 @@ export interface AlterImagePixelsArgs {
   canvas: EventCanvas;
   point1: Point;
   point2: Point;
+  isNewLine: boolean;
 }
 
 export function alterImagePixels({
@@ -61,6 +104,7 @@ export function alterImagePixels({
   canvas,
   point1,
   point2,
+  isNewLine,
 }: AlterImagePixelsArgs) {
   // Get the initial current scaling of the image. It doesn't matter if we use scaleX or scaleY
   // since the image is a square
@@ -82,7 +126,7 @@ export function alterImagePixels({
 
   let points = getContinuousPoints(scalePoint(point1), scalePoint(point2));
 
-  const { isAdmin, strokeColor, strokeWidth, pixelsChanged } = useCanvasState.getState();
+  const { isAdmin, strokeColor, strokeWidth, currentChanges } = useCanvasState.getState();
 
   if (strokeWidth > 1) {
     // Multiply points by stroke width if it's greater than 1
@@ -92,7 +136,14 @@ export function alterImagePixels({
   // Filter out out-of-bounds points
   points = points.filter(({ x, y }) => x >= 0 && x < size && y >= 0 && y < size);
 
-  const nextPixelsChanged = new Map(pixelsChanged);
+  const newChanges = [...currentChanges];
+  if (isNewLine || !newChanges[newChanges.length - 1]) {
+    newChanges.push(new Map());
+  }
+  // The line above ensures newChanges always has a last element, but tsc disagrees :/
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const nextPixelsChanged = newChanges[newChanges.length - 1]!;
+
   const pixelLimit = isAdmin ? MAX_PIXELS_PER_TXN_ADMIN : MAX_PIXELS_PER_TXN;
   for (const point of points) {
     if (nextPixelsChanged.size >= pixelLimit) break;
@@ -117,7 +168,7 @@ export function alterImagePixels({
     canvas.renderAll();
     cleanUp();
   });
-  useCanvasState.setState({ pixelsChanged: nextPixelsChanged });
+  useCanvasState.setState({ currentChanges: newChanges });
 }
 
 /**

--- a/frontend2/src/components/DrawingControls/DrawModeToggle.tsx
+++ b/frontend2/src/components/DrawingControls/DrawModeToggle.tsx
@@ -19,6 +19,7 @@ export function DrawModeToggle() {
     <div className={stack({ gap: 16, align: "center" })}>
       <Button
         iconOnly
+        rounded
         aria-label={isViewOnly ? "Go to Draw Mode" : "Back to View Only"}
         disabled={isViewOnly && !connected}
         onClick={() => {

--- a/frontend2/src/components/DrawingControls/PaintInfo.tsx
+++ b/frontend2/src/components/DrawingControls/PaintInfo.tsx
@@ -5,7 +5,7 @@ import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 
 import { MAX_PIXELS_PER_TXN, MAX_PIXELS_PER_TXN_ADMIN } from "@/constants/canvas";
-import { useCanvasState } from "@/contexts/canvas";
+import { useAggregatedPixelsChanged, useCanvasState } from "@/contexts/canvas";
 
 import { PaintIcon } from "../Icons/PaintIcon";
 import { removeToast, toast } from "../Toast";
@@ -15,7 +15,8 @@ export interface PaintInfoProps {
 }
 
 export function PaintInfo({ direction }: PaintInfoProps) {
-  const pixelsChanged = useCanvasState((s) => s.pixelsChanged);
+  const currentChanges = useCanvasState((s) => s.currentChanges);
+  const pixelsChanged = useAggregatedPixelsChanged(currentChanges);
   const changedPixelsCount = pixelsChanged.size;
   const isAdmin = useCanvasState((s) => s.isAdmin);
   const pixelLimit = isAdmin ? MAX_PIXELS_PER_TXN_ADMIN : MAX_PIXELS_PER_TXN;

--- a/frontend2/src/utils/assertUnreachable.ts
+++ b/frontend2/src/utils/assertUnreachable.ts
@@ -1,0 +1,23 @@
+/**
+ * By only accepting a `never` value, this function lets you assert that a block
+ * of code is unreachable at build time. If the unreachable block of code is
+ * somehow hit during runtime, an error will be thrown.
+ *
+ * @example
+ * // Exhaustive switch statement
+ * const value = "foo" as "foo" | "bar" | "baz";
+ * switch (value) {
+ *   case "foo":
+ *     // logic
+ *   case "bar":
+ *     // logic
+ *   case "baz":
+ *     // logic
+ *   default:
+ *     // Throws error during type-checking process
+ *     assertUnreachable(value, "Unrecognized value received");
+ * }
+ */
+export const assertUnreachable = (value: never, errorMessage?: string) => {
+  throw new Error(errorMessage || `Unreachable value received: ${JSON.stringify(value)}`);
+};


### PR DESCRIPTION
The clear button has been changed to an undo button. When clicked, the last continuous line you drew will be removed. You can keep clicking undo until all your staged changes have been removed.

Additionally, a small button has been added to the footer on mobile to send you back to view only mode.

<img width="1250" alt="Screenshot 2023-10-14 at 4 01 41 PM" src="https://github.com/aptos-labs/graffio/assets/25761639/06035ac7-24f4-4222-a0b7-fd028a577b45">
<img width="568" alt="Screenshot 2023-10-14 at 4 01 26 PM" src="https://github.com/aptos-labs/graffio/assets/25761639/b4e27ee8-6169-4f23-98e3-d063e8ccd4a1">
