### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/frontend2/package.json
+++ b/frontend2/package.json
@@ -33,6 +33,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-use-measure": "^2.1.1",
+    "tinykeys": "^2.1.0",
     "zustand": "^4.4.3"
   },
   "devDependencies": {
@@ -56,7 +57,8 @@
   "pnpm": {
     "patchedDependencies": {
       "@types/fabric@5.3.4": "patches/@types__fabric@5.3.4.patch",
-      "fabric@5.3.0": "patches/fabric@5.3.0.patch"
+      "fabric@5.3.0": "patches/fabric@5.3.0.patch",
+      "tinykeys@2.1.0": "patches/tinykeys@2.1.0.patch"
     }
   }
 }

--- a/frontend2/patches/tinykeys@2.1.0.patch
+++ b/frontend2/patches/tinykeys@2.1.0.patch
@@ -1,0 +1,12 @@
+diff --git a/package.json b/package.json
+index d6a93bb7cce03b4836cf96deba308de0417079a3..7993b5b4300785de67a28e21fe8aea874d509846 100644
+--- a/package.json
++++ b/package.json
+@@ -15,6 +15,7 @@
+   ],
+   "exports": {
+     ".": {
++      "types": "./dist/tinykeys.d.ts",
+       "import": "./dist/tinykeys.module.js",
+       "require": "./dist/tinykeys.js"
+     }

--- a/frontend2/pnpm-lock.yaml
+++ b/frontend2/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   '@types/fabric@5.3.4':
     hash: pnuuxcwmzuwll5ajd4rgc52xmm
@@ -7,6 +11,9 @@ patchedDependencies:
   fabric@5.3.0:
     hash: 4dykullkoxscjzzjpb3t6ev3wq
     path: patches/fabric@5.3.0.patch
+  tinykeys@2.1.0:
+    hash: tvyyp45lw6kk3y5djbushphkny
+    path: patches/tinykeys@2.1.0.patch
 
 dependencies:
   '@aptos-labs/wallet-adapter-react':
@@ -63,6 +70,9 @@ dependencies:
   react-use-measure:
     specifier: ^2.1.1
     version: 2.1.1(react-dom@18.2.0)(react@18.2.0)
+  tinykeys:
+    specifier: ^2.1.0
+    version: 2.1.0(patch_hash=tvyyp45lw6kk3y5djbushphkny)
   zustand:
     specifier: ^4.4.3
     version: 4.4.3(@types/react@18.2.28)(react@18.2.0)
@@ -9366,6 +9376,11 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: false
 
+  /tinykeys@2.1.0(patch_hash=tvyyp45lw6kk3y5djbushphkny):
+    resolution: {integrity: sha512-/MESnqBD1xItZJn5oGQ4OsNORQgJfPP96XSGoyu4eLpwpL0ifO0SYR5OD76u0YMhMXsqkb0UqvI9+yXTh4xv8Q==}
+    dev: false
+    patched: true
+
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -10446,7 +10461,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/frontend2/src/components/Canvas/index.tsx
+++ b/frontend2/src/components/Canvas/index.tsx
@@ -15,6 +15,7 @@ import { useThemeChange } from "@/utils/useThemeChange";
 
 import { alterImagePixels, applyImagePatches, createSquareImage } from "./drawImage";
 import { mousePan, pinchZoom, smoothZoom, wheelPan, wheelZoom } from "./gestures";
+import { useKeyboardShortcuts } from "./keyboardShortcuts";
 import { EventCanvas, Point } from "./types";
 
 export interface CanvasProps {
@@ -32,6 +33,8 @@ export function Canvas({ height, width, baseImage }: CanvasProps) {
   const prevPointRef = useRef<Point>();
   const isGesturingRef = useRef<boolean>(false);
   const pixelArrayRef = useRef(new Uint8ClampedArray(baseImage));
+
+  useKeyboardShortcuts();
 
   useEffect(function initializeCanvas() {
     // Initialize canvas

--- a/frontend2/src/components/Canvas/keyboardShortcuts.ts
+++ b/frontend2/src/components/Canvas/keyboardShortcuts.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { KeyBindingMap, tinykeys } from "tinykeys";
+
+import { STROKE_COLORS } from "@/constants/canvas";
+import { useCanvasState } from "@/contexts/canvas";
+
+export function useKeyboardShortcuts() {
+  useEffect(() => {
+    const shortcuts: KeyBindingMap = {};
+
+    for (let n = 1; n <= 8; n++) {
+      shortcuts[`Digit${n}`] = () => {
+        useCanvasState.setState({ strokeColor: STROKE_COLORS[n - 1] });
+      };
+    }
+    for (let n = 1; n <= 8; n++) {
+      shortcuts[`Shift+Digit${n}`] = () => {
+        useCanvasState.setState({ strokeWidth: n });
+      };
+    }
+
+    const unsubscribe = tinykeys(window, shortcuts);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+}


### PR DESCRIPTION
This PR adds the following keyboard shortcuts to the canvas:

Press 1-8 to switch between the 8 available stroke colors,
Press Shift + 1-8 to set the stroke width