### PR TITLE
Add custom cursor that reflects stroke color and size

### DIFF
--- a/frontend2/panda-preset/scales.ts
+++ b/frontend2/panda-preset/scales.ts
@@ -11,6 +11,7 @@ export const radii = {
 } satisfies Tokens["radii"];
 
 export const shadows = {
+  xs: { value: "0px 0px 5px 0px rgba(0, 0, 0, 0.20)" },
   sm: { value: "0px 0px 10px 0px rgba(0, 0, 0, 0.20)" },
   md: { value: "0px 0px 20px 0px rgba(0, 0, 0, 0.20)" },
 } satisfies Tokens["shadows"];

--- a/frontend2/src/app/(home)/CanvasContainer.tsx
+++ b/frontend2/src/app/(home)/CanvasContainer.tsx
@@ -47,9 +47,17 @@ export function CanvasContainer() {
     };
   }, [network]);
 
+  const [isCursorInBounds, setIsCursorInBounds] = useState(false);
+
   return (
     <div
       ref={canvasContainer}
+      onMouseEnter={() => {
+        setIsCursorInBounds(true);
+      }}
+      onMouseLeave={() => {
+        setIsCursorInBounds(false);
+      }}
       className={flex({
         position: "relative",
         height: "100%",
@@ -60,7 +68,12 @@ export function CanvasContainer() {
       })}
     >
       {hasSize && baseImage ? (
-        <Canvas height={height} width={width} baseImage={baseImage} />
+        <Canvas
+          height={height}
+          width={width}
+          baseImage={baseImage}
+          isCursorInBounds={isCursorInBounds}
+        />
       ) : (
         canvasSkeleton
       )}

--- a/frontend2/src/components/Canvas/DrawingCursor.tsx
+++ b/frontend2/src/components/Canvas/DrawingCursor.tsx
@@ -1,0 +1,76 @@
+import { fabric } from "fabric";
+import { useEffect, useRef } from "react";
+import { css } from "styled-system/css";
+
+import { useCanvasState } from "@/contexts/canvas";
+
+import { EventCanvas } from "./types";
+
+export interface DrawingCursorProps {
+  canvas: fabric.Canvas;
+}
+
+export function DrawingCursor({ canvas }: DrawingCursorProps) {
+  const cursorRef = useRef<HTMLDivElement>(null);
+  const strokeColor = useCanvasState((s) => s.strokeColor);
+  const strokeWidth = useCanvasState((s) => s.strokeWidth);
+
+  useEffect(() => {
+    function positionCursor(this: EventCanvas, { e }: fabric.IEvent<MouseEvent>) {
+      const cursor = cursorRef.current;
+      if (!cursor) return;
+
+      cursor.style.transform = `translate(${e.x}px, ${e.y}px)`;
+    }
+
+    canvas.on("mouse:move", positionCursor);
+    return () => {
+      canvas.off("mouse:move", positionCursor);
+    };
+  }, [canvas]);
+
+  return (
+    <div
+      ref={cursorRef}
+      className={css({
+        pointerEvents: "none",
+        position: "fixed",
+        top: 0,
+        left: 0,
+      })}
+    >
+      <div
+        style={{
+          backgroundColor: strokeColor.value,
+          scale: 1 + 0.5 * strokeWidth,
+        }}
+        className={css({
+          pointerEvents: "none",
+          position: "relative",
+          transformOrigin: "top left",
+          transform: "translate(-50%, -50%)",
+          rounded: "full",
+          w: 8,
+          h: 8,
+          shadow: "xs",
+          transition: "background-color token(durations.2) ease, scale token(durations.1) ease",
+          zIndex: 1,
+          _before: {
+            content: "''",
+            pointerEvents: "none",
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            rounded: "full",
+            w: 12,
+            h: 12,
+            bg: "rgba(255, 255, 255, 0.5)",
+            shadow: "xs",
+            mixBlendMode: "multiply",
+          },
+        })}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
When drawing in the canvas, a custom cursor will be shown that changes to reflect the current stroke color and width

https://github.com/aptos-labs/graffio/assets/25761639/ef3708f4-5267-43ab-9a6d-310c51721058

