### PR TITLE
Add grid overlay to debug view

### DIFF
--- a/frontend2/src/components/Canvas/gridOverlay.ts
+++ b/frontend2/src/components/Canvas/gridOverlay.ts
@@ -1,0 +1,52 @@
+import { fabric } from "fabric";
+
+import { createTempCanvas } from "@/utils/tempCanvas";
+
+export interface CreateGridOverlayArgs {
+  size: number;
+  canvas: fabric.Canvas;
+  gridRef?: React.MutableRefObject<fabric.Image | undefined>;
+}
+
+export function createGridOverlay({ size, canvas, gridRef }: CreateGridOverlayArgs) {
+  const pixelArray = new Uint8ClampedArray(size * size * 4);
+
+  let isEvenRow = true;
+  for (let i = 0; i < pixelArray.length; i += 4) {
+    if (i % (size * 4) === 0) isEvenRow = !isEvenRow;
+    const isEven = i % 8 === 0;
+    pixelArray[i + 0] = 128; // R value
+    pixelArray[i + 1] = 128; // G value
+    pixelArray[i + 2] = 128; // B value
+    pixelArray[i + 3] = isEvenRow ? (isEven ? 51 : 0) : isEven ? 0 : 51; // A value (20% or 0%)
+  }
+
+  const [tempCanvas, cleanUp] = createTempCanvas(pixelArray, size);
+
+  fabric.Image.fromURL(
+    tempCanvas.toDataURL(),
+    function (overlay) {
+      overlay.left = 0;
+      overlay.top = 0;
+
+      // Calculate minimum dimension of fabric canvas
+      const canvasHeight = canvas.getHeight();
+      const canvasWidth = canvas.getWidth();
+      const minCanvas = Math.min(canvasHeight, canvasWidth);
+
+      // Scale overlay to fit canvas
+      overlay.scaleToHeight(minCanvas);
+      overlay.scaleToWidth(minCanvas);
+
+      // Add overlay to front of canvas
+      canvas.add(overlay);
+      overlay.bringToFront();
+
+      // Save image to ref if provided
+      if (gridRef) gridRef.current = overlay;
+
+      cleanUp();
+    },
+    { selectable: false, imageSmoothing: false, objectCaching: false, visible: false },
+  );
+}

--- a/frontend2/src/components/Canvas/index.tsx
+++ b/frontend2/src/components/Canvas/index.tsx
@@ -17,6 +17,7 @@ import { useThemeChange } from "@/utils/useThemeChange";
 import { openMobileControlsModal } from "../ControlsModal";
 import { alterImagePixels, applyImagePatches, createSquareImage } from "./drawImage";
 import { DrawingCursor } from "./DrawingCursor";
+import { createGridOverlay } from "./gridOverlay";
 import { useKeyboardShortcuts } from "./keyboardShortcuts";
 import {
   mousePan,
@@ -39,9 +40,11 @@ export interface CanvasProps {
 export function Canvas({ height, width, baseImage, isCursorInBounds }: CanvasProps) {
   const isInitialized = useCanvasState((s) => s.isInitialized);
   const isViewOnly = useCanvasState((s) => s.isViewOnly);
+  const isDebugEnabled = useCanvasState((s) => s.isDebugEnabled);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const fabricRef = useRef<fabric.Canvas>();
   const imageRef = useRef<fabric.Image>();
+  const gridRef = useRef<fabric.Image>();
   const isDrawingRef = useRef<boolean>(false);
   const prevPointRef = useRef<Point>();
   const isGesturingRef = useRef<boolean>(false);
@@ -71,6 +74,13 @@ export function Canvas({ height, width, baseImage, isCursorInBounds }: CanvasPro
       pixelArray: pixelArrayRef.current,
       canvas: newCanvas,
       imageRef,
+    });
+
+    // Grid create grid overlay for debug mode
+    createGridOverlay({
+      size: PIXELS_PER_SIDE,
+      canvas: newCanvas,
+      gridRef,
     });
 
     // Zoom into the center of the image
@@ -117,6 +127,18 @@ export function Canvas({ height, width, baseImage, isCursorInBounds }: CanvasPro
       canvas.requestRenderAll();
     },
     [height, width],
+  );
+
+  useEffect(
+    function updateGridOverlayVisibility() {
+      const canvas = fabricRef.current;
+      const gridOverlay = gridRef.current;
+      if (!canvas || !gridOverlay) return;
+
+      gridOverlay.visible = isDebugEnabled;
+      canvas.requestRenderAll();
+    },
+    [isDebugEnabled],
   );
 
   useEffect(

--- a/frontend2/src/components/Canvas/index.tsx
+++ b/frontend2/src/components/Canvas/index.tsx
@@ -135,10 +135,10 @@ export function Canvas({ height, width, baseImage, isCursorInBounds }: CanvasPro
       const gridOverlay = gridRef.current;
       if (!canvas || !gridOverlay) return;
 
-      gridOverlay.visible = isDebugEnabled;
+      gridOverlay.visible = isDebugEnabled && !isViewOnly;
       canvas.requestRenderAll();
     },
-    [isDebugEnabled],
+    [isDebugEnabled, isViewOnly],
   );
 
   useEffect(


### PR DESCRIPTION
Pressing the D key opens the debug view. This view will now overlay the canvas with a grid to help with pixel perfect drawing.

https://github.com/aptos-labs/graffio/assets/25761639/a5132d89-f0df-4033-b623-9d972e721e5d

