### PR TITLE
Network-specific ABI

### DIFF
--- a/frontend2/src/components/CanvasActions/index.tsx
+++ b/frontend2/src/components/CanvasActions/index.tsx
@@ -2,7 +2,7 @@
 
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { createEntryPayload } from "@thalalabs/surf";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { css } from "styled-system/css";
 import { flex } from "styled-system/patterns";
 
@@ -26,6 +26,8 @@ export function CanvasActions() {
   const canDrawUnlimited = useCanvasState((s) => s.canDrawUnlimited);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [coolDownLeft, setCoolDownLeft] = useState<number | null>(null);
+
+  const abi = useMemo(() => ABI(APP_CONFIG[network].canvasAddr), [network]);
 
   const shouldDisableDrawing = !isDrawingEnabled && !canDrawUnlimited;
 
@@ -82,7 +84,7 @@ export function CanvasActions() {
       colors.push(pixelChanged.color);
     }
 
-    const payload = createEntryPayload(ABI, {
+    const payload = createEntryPayload(abi, {
       function: "draw",
       type_arguments: [],
       arguments: [APP_CONFIG[network].canvasTokenAddr, xs, ys, colors],

--- a/frontend2/src/components/ConnectWalletModal/useCanDrawUnlimited.ts
+++ b/frontend2/src/components/ConnectWalletModal/useCanDrawUnlimited.ts
@@ -12,7 +12,9 @@ export function useCanDrawUnlimited(address: string | undefined) {
   useEffect(() => {
     if (!address) return;
 
-    const client = createClient({ nodeUrl: APP_CONFIG[network].rpcUrl }).useABI(ABI);
+    const canvasModuleAddress = APP_CONFIG[network].canvasAddr;
+    const abi = ABI(canvasModuleAddress);
+    const client = createClient({ nodeUrl: APP_CONFIG[network].rpcUrl }).useABI(abi);
 
     const fetchCanDrawUnlimited = async () => {
       const canDrawUnlimited = (

--- a/frontend2/src/constants/abi.ts
+++ b/frontend2/src/constants/abi.ts
@@ -1,5 +1,5 @@
-export const ABI = {
-  address: "0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23",
+export const ABI = (moduleAddress: string) => ({
+  address: moduleAddress,
   name: "canvas_token",
   friends: [],
   exposed_functions: [
@@ -11,7 +11,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: [],
@@ -24,7 +24,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: [],
@@ -36,7 +36,7 @@ export const ABI = {
       is_view: true,
       generic_type_params: [],
       params: [
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: ["bool"],
@@ -49,7 +49,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
       ],
       return: [],
     },
@@ -61,7 +61,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
       ],
       return: [],
     },
@@ -92,7 +92,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
       ],
       return: [],
     },
@@ -104,7 +104,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "vector<u16>",
         "vector<u16>",
         "vector<u8>",
@@ -119,7 +119,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
       ],
       return: [],
     },
@@ -130,7 +130,7 @@ export const ABI = {
       is_view: true,
       generic_type_params: [],
       params: [
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: ["bool"],
@@ -142,7 +142,7 @@ export const ABI = {
       is_view: true,
       generic_type_params: [],
       params: [
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: ["bool"],
@@ -154,7 +154,7 @@ export const ABI = {
       is_view: true,
       generic_type_params: [],
       params: [
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: ["bool"],
@@ -167,7 +167,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: [],
@@ -180,7 +180,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "address",
       ],
       return: [],
@@ -193,7 +193,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "0x1::string::String",
       ],
       return: [],
@@ -206,7 +206,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "u64",
       ],
       return: [],
@@ -219,7 +219,7 @@ export const ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "0x1::object::Object<0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::Canvas>",
+        `0x1::object::Object<${moduleAddress}::canvas_token::Canvas>`,
         "u64",
       ],
       return: [],
@@ -234,7 +234,7 @@ export const ABI = {
       fields: [
         {
           name: "config",
-          type: "0x915efe6647e0440f927d46e39bcb5eb040a7e567e1756e002073bc6e26f2cd23::canvas_token::CanvasConfig",
+          type: `${moduleAddress}::canvas_token::CanvasConfig`,
         },
         { name: "pixels", type: "0x1::smart_table::SmartTable<u32, u8>" },
         { name: "last_contribution_s", type: "0x1::table::Table<address, u64>" },
@@ -267,4 +267,4 @@ export const ABI = {
       fields: [{ name: "table", type: "0x1::table::Table<T0, T1>" }],
     },
   ],
-} as const;
+} as const);


### PR DESCRIPTION
Testnet and Mainnet have their canvas modules installed under different addresses.
With this change we make sure to use the right address depending on the network.